### PR TITLE
Adding ability to add additional principal to trusted policy

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -38,6 +38,14 @@ data "aws_iam_policy_document" "mwaa_assume" {
       type        = "Service"
       identifiers = ["s3.amazonaws.com"]
     }
+    # Dynamic block to add additional principals
+    dynamic "principals" {
+      for_each = var.additional_principal_arns
+      content {
+        type        = "AWS"
+        identifiers = [principals.value]
+      }
+    }
   }
 }
 #tfsec:ignore:AWS099

--- a/variables.tf
+++ b/variables.tf
@@ -157,6 +157,12 @@ variable "iam_role_name" {
   default     = null
 }
 
+variable "additional_principal_arns" {
+  description = "List of additional AWS principal ARNs"
+  type        = list(string)
+  default     = []
+}
+
 variable "iam_role_permissions_boundary" {
   description = "IAM role Permission boundary"
   type        = string


### PR DESCRIPTION
## What does this PR do?

This PR introduces the ability to specify a list of additional AWS principal ARNs in the IAM policy for MWAA executor role (Amazon Managed Workflows for Apache Airflow). A new variable ```additional_principal_arns``` has been added to allow the inclusion of extra principal ARNs as needed.


### Changes:

New Variable: ```additional_principal_arns```, a list to hold additional AWS principal ARNs.
Dynamic Block in IAM Policy Document: Extended the aws_iam_policy_document for mwaa_assume to dynamically include principals based on the additional_principal_arns variable.

