### PR TITLE
Allow for EKS support in MWAA execution role

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -94,7 +94,8 @@ data "aws_iam_policy_document" "mwaa" {
     actions = [
       "logs:DescribeLogGroups",
       "cloudwatch:PutMetricData",
-      "s3:GetAccountPublicAccessBlock"
+      "s3:GetAccountPublicAccessBlock",
+      "eks:DescribeCluster
     ]
     resources = [
       "*"


### PR DESCRIPTION
### What does this PR do?

This will allow MWAA to have permissions to get the EKS kube config for interacting with EKS clusters

### Motivation

We use MWAA with EKS and it requires this permission to dynamically retrieve a clusters kube-config.  We follow the permissions from https://docs.aws.amazon.com/mwaa/latest/userguide/mwaa-eks-example.html

### More
- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
